### PR TITLE
Make no-underscore-dangle specific

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,15 @@ module.exports = {
     // XXX: this *should* be taken care of by eslint-import-resolver-meteor, investigate.
     'import/no-extraneous-dependencies': 0,
 
-    'no-underscore-dangle': [2, {allow: ['_id', '_ensureIndex']}],
+    'no-underscore-dangle': [
+      'error',
+      {
+        allow: [
+          '_id',
+          '_ensureIndex'
+        ]
+      }
+    ],
     'object-shorthand': [
       'error',
       'always',

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
     // XXX: this *should* be taken care of by eslint-import-resolver-meteor, investigate.
     'import/no-extraneous-dependencies': 0,
 
-    'no-underscore-dangle': 0,
+    'no-underscore-dangle': [2, {allow: ['_id', '_ensureIndex']}],
     'object-shorthand': [
       'error',
       'always',


### PR DESCRIPTION
Instead of turning off no-underscore-dangle, it would be better to allow specific Meteor things that have it.

In my projects, I've only ever used `_id`, and `_ensureIndex`. I'm not sure if there are others.